### PR TITLE
Update download button icon and color

### DIFF
--- a/static/css/interactive-property-map.css
+++ b/static/css/interactive-property-map.css
@@ -316,13 +316,13 @@
 .download-geojson-link {
   margin-left: 4px; /* Reduced space between layer title and download icon */
   text-decoration: none;
-  color: #28a745; /* Green color for the download icon */
+  color: green; /* Green color for the download icon */
   font-size: 0.9em; /* Slightly smaller than layer title if needed */
   cursor: pointer;
 }
 
 .download-geojson-link:hover {
-  color: #1e7e34; /* Darker green on hover */
+  color: darkgreen; /* Darker green on hover */
   text-decoration: none; /* Keep no underline on hover, or add if preferred */
 }
 

--- a/static/js/interactive-property-map.js
+++ b/static/js/interactive-property-map.js
@@ -384,7 +384,7 @@ function addDownloadLinksToLayerSwitcher() {
         if (isGeoJSONFormat || (typeof url === 'string' && url.toLowerCase().endsWith('.geojson'))) {
           const downloadLink = document.createElement('a');
           downloadLink.href = url;
-          downloadLink.innerHTML = '📥'; // Updated Download icon (Inbox Tray)
+          downloadLink.innerHTML = '⭳'; // Updated Download icon (U+2B73)
           downloadLink.title = `Download ${layerTitle}`;
           downloadLink.className = 'download-geojson-link';
 


### PR DESCRIPTION
- Changed download icon to U+2B73 (⭳).
- Set icon color to green, with darkgreen on hover.